### PR TITLE
Add .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
+github:
+  description: "Auxiliary testing files for Apache Arrow"
+  homepage: https://arrow.apache.org/
+  labels:
+    - apache-arrow
+  enabled_merge_buttons:
+    merge: false
+    rebase: false
+    squash: true
+  protected_branches:
+    master:
+      required_linear_history: true
+
+notifications:
+  commits: commits@arrow.apache.org
+  issues_status: issues@arrow.apache.org
+  issues_comment: github@arrow.apache.org
+  pullrequests: github@arrow.apache.org


### PR DESCRIPTION
This is based on
https://github.com/apache/arrow-go/blob/main/.asf.yaml .

I want to use github@ not issues@ for PR related notifications like other our repositories do.

For example,
https://lists.apache.org/thread/hsqrm5n38wbqywndkd3vckpkh50l6zlc used issues@ not github@.